### PR TITLE
注釈エリアの文字カラーを調整

### DIFF
--- a/style.css
+++ b/style.css
@@ -13,7 +13,7 @@ header h1 {
 .note {
   padding: 1em;
   border: dotted 1px #ccc;
-  color: #777;
+  color: #333;
   background-color: #ffffee;
 }
 .toc {


### PR DESCRIPTION
注釈エリアの文字カラーが薄くて見づらいので、少し濃くした。